### PR TITLE
support serverless >2.26.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,8 +98,11 @@ class ServerlessPluginColocate {
      * @returns {Promise}
      */
     printColocateUsage() {
-        this.serverless.cli.generateCommandsHelp(["colocate"]);
 
+        if (this.serverless.cli.generateCommandsHelp){
+            this.serverless.cli.generateCommandsHelp(["colocate"]);    
+        }
+        
         return BbPromise.resolve();
     }
 
@@ -131,6 +134,15 @@ class ServerlessPluginColocate {
     mergeCodeFragmentsIntoService() {
         this.getConfigFragmentFilenames()
             .forEach(this.mergeConfigFragmentIntoService.bind(this));
+
+        //
+        // after serverless@2.26.0. variables are resolved before the plugins are called
+        // thus we need to explicitly repopulate variables after merging the fragments
+        //
+        if (this.serverless.variables && this.serverless.variables.populateService && 
+            typeof this.serverless.variables.populateService === 'function') {
+            this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);        
+        }
     }
 
     /**


### PR DESCRIPTION
Problem: 
serverless 2.26.0 introduced a [new variables engine](https://github.com/serverless/serverless/pull/8987) which moved the resolving of variables to before the plugins are called. Thus any variables inside the plugin fragments are not resolved correctly. 



Solution:
Explicitly trigger a second pass of variable resolution after the file fragments have been merged together