### PR TITLE
Updates for serverless ^3.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "globby": "^8.0.1",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.10"
+  },
+  "peerDependencies":{
+    "serverless": "^3.26.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ class ServerlessPluginColocate {
              
         }
 
-        this.extendServiceConfigurationWithObject([],configFragment) this.extendServiceConfigurationWithObject([],configFragment);
+        this.extendServiceConfigurationWithObject([],configFragment);
     }
     
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -134,15 +134,6 @@ class ServerlessPluginColocate {
     mergeCodeFragmentsIntoService() {
         this.getConfigFragmentFilenames()
             .forEach(this.mergeConfigFragmentIntoService.bind(this));
-
-        //
-        // after serverless@2.26.0. variables are resolved before the plugins are called
-        // thus we need to explicitly repopulate variables after merging the fragments
-        //
-        if (this.serverless.variables && this.serverless.variables.populateService && 
-            typeof this.serverless.variables.populateService === 'function') {
-            this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);        
-        }
     }
 
     /**
@@ -181,7 +172,7 @@ class ServerlessPluginColocate {
              
         }
 
-        this.serverless.service = _.merge(this.serverless.service || {}, configFragment);
+        this.extendServiceConfigurationWithObject([],configFragment) this.extendServiceConfigurationWithObject([],configFragment);
     }
     
     /**
@@ -200,6 +191,43 @@ class ServerlessPluginColocate {
   
         return originalLocation;
     }    
+
+     /**
+     * Append a key to the list of configurationPathKeys
+     *
+     * @param configurationPathKeys
+     * @param key
+     */
+    appendConfigurationPathKey(configurationPathKeys, key){
+        let keys_ = _.cloneDeep(configurationPathKeys)
+        keys_.push(key)
+        return keys_;
+    }
+
+    /**
+     * Extend the serverless Configuration with and object
+     *
+     * @param configurationPathKeys array of path keys e.g. [['provider'],['name']]
+     * @param value e.g. aws
+     */
+    extendServiceConfigurationWithObject(configurationPathKeys, value){
+
+        if (!configurationPathKeys){
+            configurationPathKeys = []
+        }
+
+        if (typeof value == 'object'){
+            Object.keys(value).forEach(key => {
+                  this.extendServiceConfigurationWithObject(this.appendConfigurationPathKey(configurationPathKeys, key), value[key]);
+                });
+        }
+        else if (Array.isArray(value)){
+            value.forEach((element) => this.extendServiceConfigurationWithObject(configurationPathKeys, element));
+        }
+        else if (value){
+            this.serverless.extendConfiguration(configurationPathKeys, value);
+        }
+    }
 
     /**
      * Search service paths recursively for Serverless configration fragment files

--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ class ServerlessPluginColocate {
             configurationPathKeys = []
         }
 
-        if (typeof value == 'object'){
+        if (value && typeof value == 'object'){
             Object.keys(value).forEach(key => {
                   this.extendServiceConfigurationWithObject(this.appendConfigurationPathKey(configurationPathKeys, key), value[key]);
                 });
@@ -241,7 +241,7 @@ class ServerlessPluginColocate {
         const patterns = this.getCustomDefaultInclude() || ["**/*.yml", "**/*.yaml"];
 
         const defaultExclude = this.getCustomDefaultExclude() ||
-            ["serverless.yml", "node_modules/**"];
+            ["serverless.yml", "node_modules/**", "vendor/**"];
 
         defaultExclude.forEach((pattern) => addExcludePattern(pattern, patterns));
 


### PR DESCRIPTION
After 2.25.0 this plugin stopped working. There was a re-write of the variable handling and it became difficult to dynamically register external entries to the service configuration.

In 3.26.0 a new API was added support parsing of variables.
serverless.extendConfiguration(configurationPathKeys, value);

This updates to use the new API.